### PR TITLE
Simplify network requests 

### DIFF
--- a/Toxygates/src/panomicon/NetworkHandling.scala
+++ b/Toxygates/src/panomicon/NetworkHandling.scala
@@ -53,6 +53,7 @@ class NetworkHandling(context: Context, matrixHandling: MatrixHandling) {
     )
   }
 
+  /* Alter this label for the sake of legibility for the end user (to help distinguish from mRNA) */
   private def normalizeNodeType(t: String) = t match {
     case "miRNA" => "microRNA"
     case _ => t

--- a/Toxygates/src/panomicon/NetworkHandling.scala
+++ b/Toxygates/src/panomicon/NetworkHandling.scala
@@ -15,9 +15,9 @@ import upickle.default.writeJs
 class NetworkHandling(context: Context, matrixHandling: MatrixHandling) {
   lazy val netLoader = new NetworkLoader(context, context.config.data.mirnaDir)
 
-  def loadNetwork(valueType: ValueType, pageSize: Int, netParams: NetworkParams): Network = {
+  def loadNetwork(valueType: ValueType, netParams: NetworkParams): Network = {
 
-    var r = new TargetTableBuilder
+    val r = new TargetTableBuilder
     for (t <- netLoader.mirnaTargetTable(netParams.mirnaSource)) {
       r.addAll(t)
     }
@@ -32,7 +32,7 @@ class NetworkHandling(context: Context, matrixHandling: MatrixHandling) {
     val mainInitProbes = netParams.matrix1.probes
     val sideGroups = matrixHandling.filledGroups(netParams.matrix2)
     val netController = netLoader.load(targetTable, mainGroups, mainInitProbes.toArray,
-      sideGroups, valueType, pageSize)
+      sideGroups, valueType)
     netController.makeNetwork
   }
 

--- a/Toxygates/src/panomicon/ScalatraJSONServlet.scala
+++ b/Toxygates/src/panomicon/ScalatraJSONServlet.scala
@@ -240,9 +240,7 @@ class ScalatraJSONServlet(scontext: ServletContext) extends ScalatraServlet
       params.getOrElse("valueType", "Folds"))
 
     val network = networkHandling.loadNetwork(valueType, netParams)
-    write(Map(
-      "interactions" -> networkHandling.interactionsToJson(network.interactions().asScala)
-    ))
+    write(networkHandling.networkToJson(network))
   }
 
   def associationToJSON(a: Association): Seq[(String, Seq[(String, String)])] = {

--- a/Toxygates/src/panomicon/ScalatraJSONServlet.scala
+++ b/Toxygates/src/panomicon/ScalatraJSONServlet.scala
@@ -167,6 +167,8 @@ class ScalatraJSONServlet(scontext: ServletContext) extends ScalatraServlet
   }
 
   /*
+  Obtain a matrix page.
+
   URL parameters: valueType, offset, limit
   other parameters in MatrixParams
   Example request:
@@ -211,18 +213,33 @@ class ScalatraJSONServlet(scontext: ServletContext) extends ScalatraServlet
     ))
   }
 
+  /*
+  Obtain a network as a list of interactions.
+  Example request:
+
+  { "groups1": [
+        { "name": "a", "sampleIds":
+            [ "003017689013", "003017689014",  "003017689015", "003017688002", "003017688003", "003017688004"]
+        },
+    ],
+    "probes1": [ "p00001", "p00002", "p00003" ],
+    "groups2": [
+    { "name": "b", "sampleIds":
+            [ "mirna0001", "mirna0002", "mirna0003" ]
+        },
+    ],
+    "associationSource": "miRDB",
+    "associationLimit": "90"
+  }
+   */
   post("/network") {
     contentType = "text/json"
     val netParams: json.NetworkParams = read[json.NetworkParams](request.body)
     println(s"Load request: $netParams")
     val valueType = ValueType.valueOf(
       params.getOrElse("valueType", "Folds"))
-    val defaultLimit = 100
-    val pageSize = params.get("limit") match {
-      case Some(l) => l.toInt
-      case None => defaultLimit
-    }
-    val network = networkHandling.loadNetwork(valueType, pageSize, netParams)
+
+    val network = networkHandling.loadNetwork(valueType, netParams)
     write(Map(
       "interactions" -> networkHandling.interactionsToJson(network.interactions().asScala)
     ))

--- a/Toxygates/src/panomicon/ScalatraJSONServlet.scala
+++ b/Toxygates/src/panomicon/ScalatraJSONServlet.scala
@@ -214,7 +214,13 @@ class ScalatraJSONServlet(scontext: ServletContext) extends ScalatraServlet
   }
 
   /*
-  Obtain a network as a list of interactions.
+  Obtain an interaction network, for two sets of sample groups (of two omics types, e.g. mRNA and miRNA),
+  based on an interaction source for the two types.
+  The result is a list of interactions and a list of nodes, with expression values for the given sample groups
+  attached to the nodes.
+  Optionally, a set of probes for the first set of sample groups can be specified.
+  If it is left empty, all the probes in the platform that are defined for the sample groups will be returned.
+
   Example request:
 
   { "groups1": [
@@ -231,7 +237,7 @@ class ScalatraJSONServlet(scontext: ServletContext) extends ScalatraServlet
     "associationSource": "miRDB",
     "associationLimit": "90"
   }
-   */
+  */
   post("/network") {
     contentType = "text/json"
     val netParams: json.NetworkParams = read[json.NetworkParams](request.body)

--- a/Toxygates/src/panomicon/json/package.scala
+++ b/Toxygates/src/panomicon/json/package.scala
@@ -59,7 +59,8 @@ case class MatrixParams(groups: Seq[Group], probes: Seq[String] = Seq(),
 }
 
 object NetworkParams { implicit val rw: RW[NetworkParams] = macroRW }
-case class NetworkParams(matrix1: MatrixParams, matrix2: MatrixParams,
+case class NetworkParams(groups1: Seq[Group], probes1: Seq[String] = Seq(),
+                         groups2: Seq[Group],
                          associationSource: String, associationLimit: String = null) {
   import java.lang.{Double => JDouble}
 
@@ -69,6 +70,9 @@ case class NetworkParams(matrix1: MatrixParams, matrix2: MatrixParams,
       limit.getOrElse(null: JDouble),
       0, null, null, null)
   }
+
+  def matrix1: MatrixParams = MatrixParams(groups1, probes1)
+  def matrix2: MatrixParams = MatrixParams(groups2)
 }
 
 object Encoders {

--- a/Toxygates/src/t/gwt/viewer/client/network/NetworkVisualizationDialog.java
+++ b/Toxygates/src/t/gwt/viewer/client/network/NetworkVisualizationDialog.java
@@ -86,7 +86,6 @@ public class NetworkVisualizationDialog implements LoadNetworkDialog.Delegate {
   public void initWindow(@Nullable Network network) {
     createPanel();
     exportPendingRequestHandling();
-    truncationCheck(network);
 
     Utils.loadHTML(GWT.getModuleBaseURL() + "network-visualization/uiPanel.html", new Utils.HTMLCallback() {
       @Override
@@ -105,20 +104,10 @@ public class NetworkVisualizationDialog implements LoadNetworkDialog.Delegate {
 
   public void loadNetwork(Network network) {
     storeNetwork(NetworkConversion.convertNetworkToJS(network));
-    truncationCheck(network);
     changeNetwork();
   }
 
   private ShowOnceDialog messageDialog = new ShowOnceDialog();
-  private void truncationCheck(Network network) {
-    if (network.wasTruncated()) {
-      messageDialog
-          .showIfDesired("Warning: for performance reasons, the network was truncated from "
-              + network.trueSize() + " to " + Network.MAX_NODES
-          + " main nodes, using the current sort order. "
-          + "You may wish to apply filtering.");
-    }
-  }
 
   private void injectOnce(final Runnable callback) {
     if (!injected) {

--- a/Toxygates/src/t/gwt/viewer/client/rpc/NetworkService.java
+++ b/Toxygates/src/t/gwt/viewer/client/rpc/NetworkService.java
@@ -58,13 +58,12 @@ public interface NetworkService extends RemoteService {
    * MatrixService.  
    * @param sideColumns Columns for the side table. Probes will be determined by 
    *    associations from the main table.
-   * @param Number of rows on the first page of the main table.
    * @return Information about the loaded network.
    */
   NetworkInfo loadNetwork(String mainId, List<Group> mainColumns, 
                           String[] mainProbes,
                           String sideId, List<Group> sideColumns, 
-                          ValueType typ, int mainPageSize);
+                          ValueType typ);
 
   /**
    * Obtain a view of the current network, identified by the id of the main table matrix,

--- a/Toxygates/src/t/gwt/viewer/client/rpc/NetworkServiceAsync.java
+++ b/Toxygates/src/t/gwt/viewer/client/rpc/NetworkServiceAsync.java
@@ -33,7 +33,7 @@ public interface NetworkServiceAsync {
   void setMirnaSources(MirnaSource[] sources, AsyncCallback<Void> callback);
 
   void loadNetwork(String mainId, List<Group> mainColumns, String[] mainProbes, 
-                   String sideId, List<Group> sideColumns, ValueType typ, int mainPageSize,
+                   String sideId, List<Group> sideColumns, ValueType typ,
       AsyncCallback<NetworkInfo> callback);
 
   void prepareNetworkDownload(Network network, Format format, String messengerWeightColumn,

--- a/Toxygates/src/t/gwt/viewer/client/table/DualTableView.java
+++ b/Toxygates/src/t/gwt/viewer/client/table/DualTableView.java
@@ -60,7 +60,7 @@ public class DualTableView extends TableView implements NetworkMenu.Delegate, Ne
   protected final static String mainMatrix = NetworkService.tablePrefix + "MAIN";
   protected final static String sideMatrix = NetworkService.tablePrefix + "SIDE";
   
-  final static int MAX_SECONDARY_ROWS = Network.MAX_NODES;
+  final static int MAX_SECONDARY_ROWS = 100;
 
   protected NetworkServiceAsync networkService;
   

--- a/Toxygates/src/t/gwt/viewer/client/table/DualTableView.java
+++ b/Toxygates/src/t/gwt/viewer/client/table/DualTableView.java
@@ -325,12 +325,11 @@ public class DualTableView extends TableView implements NetworkMenu.Delegate, Ne
   }
   
   @Override
-  public void loadInitialMatrix(ValueType valueType, int initPageSize,
-		  List<ColumnFilter> initFilters) {
+  public void loadInitialMatrix(ValueType valueType, List<ColumnFilter> initFilters) {
     networkService.loadNetwork(mainMatrix, ClientGroup.convertToGroups(expressionTable.chosenColumns), 
         chosenProbes, sideMatrix, 
         ClientGroup.convertToGroups(sideExpressionTable.chosenColumns), 
-        valueType, initPageSize, 
+        valueType,
       new PendingAsyncCallback<NetworkInfo>(screen.manager(), "Unable to load network") {
         
         @Override

--- a/Toxygates/src/t/gwt/viewer/client/table/ETMatrixManager.java
+++ b/Toxygates/src/t/gwt/viewer/client/table/ETMatrixManager.java
@@ -96,10 +96,8 @@ public class ETMatrixManager {
     /**
      * Perform an initial matrix load. The method should load data and then call
      * setInitialMatrix.
-     * @param initPageSize initial page size. Provided as a hint to the loader to optimize
-     * certain operations.
      */
-    void loadInitialMatrix(ValueType valueType, int initPageSize, List<ColumnFilter> initFilters);
+    void loadInitialMatrix(ValueType valueType, List<ColumnFilter> initFilters);
   }
 
   public ETMatrixManager(Screen screen, TableFlags flags, Delegate delegate, Loader loader,
@@ -342,7 +340,7 @@ public class ETMatrixManager {
     delegate.setEnabled(false);
     List<ColumnFilter> initFilters = preserveFilters ? lastColumnFilters : new ArrayList<ColumnFilter>();
     asyncProvider.updateRowCount(0, false);
-    loader.loadInitialMatrix(chosenValueType, NavigationTools.INIT_PAGE_SIZE, initFilters);
+    loader.loadInitialMatrix(chosenValueType, initFilters);
   }
 
   class KCAsyncProvider extends AsyncDataProvider<ExpressionRow> {

--- a/Toxygates/src/t/gwt/viewer/client/table/TableView.java
+++ b/Toxygates/src/t/gwt/viewer/client/table/TableView.java
@@ -231,8 +231,7 @@ public class TableView extends DataView implements ExpressionTable.Delegate,
   }
 
   @Override
-  public void loadInitialMatrix(ValueType valueType, 
-		  int initPageSize, List<ColumnFilter> initFilters) {
+  public void loadInitialMatrix(ValueType valueType, List<ColumnFilter> initFilters) {
     matrixService.loadMatrix(defaultMatrix, ClientGroup.convertToGroups(chosenColumns), 
         chosenProbes, valueType, initFilters, 
       new AsyncCallback<ManagedMatrixInfo>() {

--- a/Toxygates/src/t/server/viewer/network/ManagedNetwork.scala
+++ b/Toxygates/src/t/server/viewer/network/ManagedNetwork.scala
@@ -42,15 +42,15 @@ class ManagedNetwork(mainParams: LoadParams,
                      val sideMatrix: ManagedMatrix,
                      var targets: TargetTable,
                      platforms: PlatformRegistry,
-                     var currentPageSize: Int,
                      sideIsMRNA: Boolean) extends ManagedMatrix(mainParams) {
 
-  protected var currentPageRows: Option[(Int, Int)] = None
+  //Offset and length of the current page in the main matrix, if any
+  var currentPageStart: Int = 0
+  var currentPageLength: Int = current.rows
 
   override def getPageView(offset: Int, length: Int): Seq[ExpressionRow] = {
     val r = super.getPageView(offset, length)
-    currentPageRows = Some((offset, r.size))
-    updateSideMatrix()
+    updateSideMatrix(offset, length)
     r
   }
 
@@ -58,10 +58,11 @@ class ManagedNetwork(mainParams: LoadParams,
    * To be called when the superclass' current view has changed.
    * Obtains the relevant rows for and reloads the side matrix
    * accordingly.
+   * pageStartLength is a pair of (probe offset, page length) for the main matrix.
    */
-  def updateSideMatrix() {
-    val offset = currentPageRows.map(_._1).getOrElse(0)
-    val length = currentPageRows.map(_._2).getOrElse(currentPageSize)
+  def updateSideMatrix(offset: Int, length: Int) {
+    currentPageStart = offset
+    currentPageLength = length
     if (targets.isEmpty) {
       println("Warning: targets table is empty. No side table can be constructed.")
     }

--- a/Toxygates/src/t/server/viewer/network/NetworkController.scala
+++ b/Toxygates/src/t/server/viewer/network/NetworkController.scala
@@ -40,14 +40,13 @@ import t.shared.viewer.network.{Network, NetworkInfo}
  */
 class NetworkController(context: Context, params: ControllerParams,
                         val sideController: MatrixController, targets: TargetTable,
-                        initMainPageSize: Int,
                         sideIsMRNA: Boolean) extends MatrixController(context, params) {
   def sideMatrix = sideController.managedMatrix
 
   type Mat = ManagedNetwork
 
   override def finish(mm: ManagedMatrix): Mat = {
-    new ManagedNetwork(mm.params, sideMatrix, targets, context.platformRegistry, initMainPageSize, sideIsMRNA)
+    new ManagedNetwork(mm.params, sideMatrix, targets, context.platformRegistry, sideIsMRNA)
   }
 
   /**

--- a/Toxygates/src/t/server/viewer/rpc/NetworkServiceImpl.scala
+++ b/Toxygates/src/t/server/viewer/rpc/NetworkServiceImpl.scala
@@ -129,8 +129,7 @@ class NetworkServiceImpl extends StatefulServlet[NetworkState] with NetworkServi
   def distinctInteractions(net: Network): Network = {
     val all = net.interactions().asScala.groupBy(i => (i.from, i.to))
     val distinct = all.values.map(_.head)
-    new Network(net.title(), net.nodes(),
-      distinct.toList.asJava, net.wasTruncated(), net.trueSize())
+    new Network(net.title(), net.nodes(), distinct.toList.asJava)
   }
 
   def prepareNetworkDownload(mainTableId: String, format: Format,

--- a/Toxygates/src/t/server/viewer/rpc/NetworkServiceImpl.scala
+++ b/Toxygates/src/t/server/viewer/rpc/NetworkServiceImpl.scala
@@ -65,7 +65,7 @@ class NetworkState extends MatrixState {
       network.currentRowsChanged()
       //Make the count column update
       network.sideMatrix.reapplySynthetics()
-      network.updateSideMatrix()
+      network.updateSideMatrix(network.currentPageStart, network.currentPageLength)
     }
   }
 
@@ -108,14 +108,13 @@ class NetworkServiceImpl extends StatefulServlet[NetworkState] with NetworkServi
    * and the mapping between the two.
    */
   def loadNetwork(mainId: String, mainColumns: JList[Group], mainProbes: Array[String],
-                  sideId: String, sideColumns: JList[Group], typ: ValueType,
-                  mainPageSize: Int): NetworkInfo = {
+                  sideId: String, sideColumns: JList[Group], typ: ValueType): NetworkInfo = {
 
     val scSideColumns = sideColumns.asScala
     val species = groupSpecies(scSideColumns(0))
     val netController = netLoader.load(getState.targetTable.speciesFilter(species),
       mainColumns.asScala, mainProbes,
-      sideColumns.asScala, typ, mainPageSize)
+      sideColumns.asScala, typ)
 
     getState.controllers += (sideId -> netController.sideController)
     getState.controllers += mainId -> netController
@@ -150,8 +149,7 @@ class NetworkServiceImpl extends StatefulServlet[NetworkState] with NetworkServi
 class NetworkLoader(context: Context, mirnaDir: String) {
   def load(targetTable: TargetTable,
            mainColumns: Seq[Group], mainInitProbes: Array[String],
-           sideColumns: Seq[Group], valueType: ValueType,
-           mainPageSize: Int): NetworkController = {
+           sideColumns: Seq[Group], valueType: ValueType): NetworkController = {
 
     val sideMatrix = MatrixController(context, sideColumns, Seq(), valueType)
 
@@ -164,7 +162,7 @@ class NetworkLoader(context: Context, mirnaDir: String) {
     //The network controller (actually the managed network) will ensure that
     //the side matrix stays updated when the main matrix changes
     val net = new NetworkController(context, netControllerParams,
-      sideMatrix, targetTable, mainPageSize, sideIsMRNA)
+      sideMatrix, targetTable, sideIsMRNA)
 
     val mainMatrix = net.managedMatrix
     if (mainInitProbes.nonEmpty) {

--- a/Toxygates/src/t/shared/viewer/network/Network.java
+++ b/Toxygates/src/t/shared/viewer/network/Network.java
@@ -30,26 +30,14 @@ import java.util.stream.Collectors;
  */
 @SuppressWarnings("serial")
 public class Network implements Serializable {
-  /**
-   * In a network with two node types, the maximum number of nodes of either of the two types.
-   * (Currently this constant is not being used)
-   */
-  public static final int MAX_EDGES = 1000;
 
-  /**
-   * Max number of overall main type nodes in the network.
-   */
-  public static final int MAX_NODES = 100;
-  
   public static final String mrnaType = "mRNA";
   public static final String mirnaType = "miRNA";
 
   private List<Interaction> interactions = new ArrayList<Interaction>();
   private List<Node> nodes = new ArrayList<Node>();
   private String title;
-  
-  private int trueSize;
-  private boolean wasTruncated;
+
   /*
    * Stores the JSON representation of the JavaScript version of this network, so that it doesn't
    * need to be computed more than once.
@@ -63,15 +51,10 @@ public class Network implements Serializable {
    * @param title
    * @param nodes
    * @param interactions
-   * @param wasTruncated Was the network truncated during construction due to being too large?
-   * @param trueSize The true number of nodes of the main node type in the network. 
    * Only defined if wasTruncated is true.
    */
-  public Network(String title, List<Node> nodes, List<Interaction> interactions,
-                 boolean wasTruncated, int trueSize) {
+  public Network(String title, List<Node> nodes, List<Interaction> interactions) {
     this(title, nodes, interactions, "");
-    this.wasTruncated = wasTruncated;
-    this.trueSize = trueSize;
   }
 
   public Network(String title,
@@ -101,12 +84,9 @@ public class Network implements Serializable {
   public String title() { return title; }
   
   public List<Node> nodes() { return nodes; }
-  
+
   public List<Interaction> interactions() { return interactions; }
 
-  public int trueSize() { return trueSize; }
-  public boolean wasTruncated() { return wasTruncated; }
-  
   public void changeTitle(String newTitle) {
     title = newTitle;
   }

--- a/Toxygates/src/t/shared/viewer/network/Network.java
+++ b/Toxygates/src/t/shared/viewer/network/Network.java
@@ -64,23 +64,7 @@ public class Network implements Serializable {
     this.interactions = interactions;
     this.jsonString = jsonString;
   }
-  
-  public List<Interaction> interactionsFrom(Node from) {
-    return interactions.stream().filter(i -> i.from.equals(from)).collect(Collectors.toList());
-  }
-  
-  public List<Interaction> interactionsTo(Node to) {
-    return interactions.stream().filter(i -> i.to.equals(to)).collect(Collectors.toList());
-  }
-  
-  public List<Interaction> interactionsFrom(String fromId) {
-    return interactionsFrom(new Node(fromId, null, null, null));
-  }
-  
-  public List<Interaction> interactionsTo(String toId) {
-    return interactionsTo(new Node(toId, null, null, null));
-  }
-  
+
   public String title() { return title; }
   
   public List<Node> nodes() { return nodes; }

--- a/Toxygates/src/t/shared/viewer/network/Node.java
+++ b/Toxygates/src/t/shared/viewer/network/Node.java
@@ -64,20 +64,7 @@ public class Node implements Serializable {
     this.type = type;
     this.weights = weights;
   }
-  
-  @Override
-  public int hashCode() {
-    return id.hashCode();
-  }
-  
-  @Override
-  public boolean equals(Object other) {
-    if (other instanceof Node) {
-      return id.equals(((Node)other).id);
-    }
-    return false;
-  }
-  
+
   public String id() { return id; }
   public String type() { return type; }
 

--- a/Toxygates/test/t/server/viewer/network/ManagedNetworkTest.scala
+++ b/Toxygates/test/t/server/viewer/network/ManagedNetworkTest.scala
@@ -62,7 +62,7 @@ class ManagedNetworkTest extends TTestSuite {
     val builder = new NetworkBuilder(targets, platforms, main, side)
     val network = builder.build
 
-    val expMainNodes = main.current.asRows take Network.MAX_NODES
+    val expMainNodes = main.current.asRows
     assert(expMainNodes.map(_.probe).toSet.subsetOf(mrnaIds.toSet))
 
     val expSideNodes = side.current.asRows

--- a/Toxygates/test/t/server/viewer/network/ManagedNetworkTest.scala
+++ b/Toxygates/test/t/server/viewer/network/ManagedNetworkTest.scala
@@ -68,7 +68,7 @@ class ManagedNetworkTest extends TTestSuite {
     val expSideNodes = side.current.asRows
     assert(expSideNodes.map(_.probe).toSet.subsetOf(mirnaIds.toSet))
 
-    val ids = (expMainNodes.toSeq ++ expSideNodes).map(_.probe)
+    val ids = (expMainNodes ++ expSideNodes).map(_.probe)
     network.nodes.asScala.map(_.id).toSet should equal(ids.toSet)
   }
 
@@ -122,7 +122,6 @@ class ManagedNetworkTest extends TTestSuite {
     }
 
     val params = ControllerParams(mainGroups, Seq(), ValueType.Folds)
-    val mainPageSize = 100
 
     //Partial MatrixController. Note: should find a more permanent solution and structure the code better
     val sideControllerParams = ControllerParams(sideGroups, Seq(), ValueType.Folds)
@@ -132,7 +131,7 @@ class ManagedNetworkTest extends TTestSuite {
     }
 
     val netCon = new NetworkController(testContext, params, sideController,
-      targets, mainPageSize, false)
+      targets, false)
     val main = netCon.managedMatrix
 
     //Check that the side table - main table correspondence agrees with what the target table says
@@ -145,7 +144,7 @@ class ManagedNetworkTest extends TTestSuite {
     main.resetSortAndFilter()
     main.targets = targets.scoreFilter(90)
     //Propagate the new target table
-    main.updateSideMatrix()
+    main.updateSideMatrix(main.currentPageStart, main.currentPageLength)
     assert(main.targets.size > 0)
     assert(main.targets.size != targets.size)
     checkNetworkInvariants(main, side, reverseLookup)


### PR DESCRIPTION
Remove filtering and sorting parameters from the request.
Stop limiting the size of the network on the server, instead letting the client decide how to handle a large network.
This is partly for simplicity, partly because sorting and filtering does not intuitively belong to the concept of an interaction network.
Also, probes can be pre-filtered prior to a network request.

Example of the new request format (`/network`):

```json
{ "groups1": [ 
        { "name": "a", "sampleIds":
            [ "GSM1223526", "GSM1223527", "GSM1223528" ]            
        }        
    ],
    "probes1": [ "M200006448", "M300012254", "M200001306", "M200008261" ],
    "groups2": [ 
    { "name": "b", "sampleIds":
            [ "GSM1223535", "GSM1223536", "GSM1223537" ]            
        }
    ],
    "associationSource": "miRDB",
    "associationLimit": "90"
}

```
Where: `groups1` identifies type 1 sample groups (e.g. mRNA), `groups2` identifies type 2 groups (e.g. miRNA), probes1 identifies probes from matrix 1 (used to select which interactions to include in the network),
`associationSource` identifies the association source, and `associationLimit` sets a cutoff for the association source (legitimate values will be different depending on the source).

Of course, strings like "GSM1223526"  must correspond to actual sample IDs in the database, and strings like "M200006448" must correspond to actual probe IDs.
`probes1` may be left empty if no specific probes are being selected. In this case, all probes that are defined for the given samples in the platform will be returned.

Example response:

```json
{
   "nodes": [
    {
      "id": "M200006448",
      "type": "mRNA",
      "weights": {
        "a(p)": "NaN",
        "a": 2.2246574557283862
      },
      "symbols": [
        "2700055K07Rik"
      ]
    },
    {
      "id": "M300012254",
      "type": "mRNA",
      "weights": {
        "a(p)": "NaN",
        "a": 2.142477053350753
      },
      "symbols": [
        "Dscr1l1"
      ]
    }] ,
"interactions": [
    {
      "from": "mmu-miR-3075-5p",
      "to": "M200006448",
      "label": "MiRDB 5.0 (score: 96.143)",
      "weight": 96.14301259004
    },
    {
      "from": "mmu-miR-3090-5p",
      "to": "M200006448",
      "label": "MiRDB 5.0 (score: 98.613)",
      "weight": 98.6126435809
    } ]
}
```


