### PR TITLE
Intermine gene list import/export API for scalatra

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -17,6 +17,11 @@ export T_DATA_DIR="kcchunk:/Users/yuji/dev/toxygates/kyoto_data"
 export T_DATA_MATDBCONFIG="#pccap=1073741824#msiz=4294967296"
 export T_INSTANCE_NAME="dev"
 
+#Intermine connection
+export T_INTERMINE_NAME=TargetMine
+export T_INTERMINE_ID=targetmine
+export T_INTERMINE_URL=https://targetmine.mizuguchilab.org
+
 # Additional back end variables for FusionAuth
 # (the values below work out of the box with the docker-compose file)
 export FUSIONAUTH_BASEURL="http://localhost:9011"

--- a/OTGTool/src/main/scala/t/sparql/PlatformStore.scala
+++ b/OTGTool/src/main/scala/t/sparql/PlatformStore.scala
@@ -87,12 +87,12 @@ class PlatformStore(val config: TriplestoreConfig) extends ListManager(config) {
     EnsemblPlatform.constructPlatformFromEnsemblGraph(triplestore, PlatformStore.context(name))
   }
 
-  /**
-   * Note, the map may only be partially populated
-   */
-  def platformTypes: Map[String, String] = {
-    Map() ++ triplestore.mapQuery(s"$tPrefixes\nSELECT ?l ?type WHERE { ?item a $itemClass; rdfs:label ?l ; " +
-      s"$platformType ?type } ").map(x => {
+  def platformOmicsTypes: Map[String, String] = {
+    Map() ++ triplestore.mapQuery(
+      s"""|$tPrefixes\n
+          | SELECT DISTINCT ?l ?type WHERE { ?item a $itemClass; rdfs:label ?l.
+          |   GRAPH ?batch { ?x a t:sample; t:platform_id ?l; t:type ?type }
+          | } """.stripMargin).map(x => {
       x("l") -> x("type")
     })
   }

--- a/OTGTool/src/main/scala/t/sparql/ProbeStore.scala
+++ b/OTGTool/src/main/scala/t/sparql/ProbeStore.scala
@@ -198,19 +198,17 @@ class ProbeStore(val config: TriplestoreConfig) extends ListManager(config) with
   }
 
   def numProbes(): Map[String, Int] = {
-    val r = triplestore.mapQuery(s"""$tPrefixes
-                                    |SELECT (count(distinct ?p) as ?n) ?l WHERE {
-                                    |  ?pl a ${PlatformStore.itemClass} ; rdfs:label ?l .
-                                    |  GRAPH ?pl {
-                                    |    ?p a t:probe.
-                                    |   }
-                                    | } GROUP BY ?l""".stripMargin)
-    if (r(0).keySet.contains("l")) {
-      Map() ++ r.map(x => x("l") -> x("n").toInt)
-    } else {
-      // no records
-      Map()
-    }
+    val r = triplestore.mapQuery(
+      s"""$tPrefixes
+         |SELECT (count(?p) as ?n) ?l WHERE {
+         |  ?pl a ${PlatformStore.itemClass} ; rdfs:label ?l .
+         |  GRAPH ?pl {
+         |    ?p a t:probe.
+         |   }
+         | } GROUP BY ?l""".stripMargin)
+    if (r.nonEmpty && r.head.keySet.contains("l")) {
+      r.map(x => x("l") -> x("n").toInt).toMap
+    } else Map.empty
   }
 
   def probeQuery(identifiers: Iterable[String], relation: String,

--- a/Toxygates/src/panomicon/IntermineHandling.scala
+++ b/Toxygates/src/panomicon/IntermineHandling.scala
@@ -1,8 +1,7 @@
 package panomicon
 
-import panomicon.json.GeneList
 import t.Context
-import t.server.viewer.intermine.IntermineConnector
+import t.server.viewer.intermine.{IntermineConnector}
 import t.shared.viewer.intermine.IntermineInstance
 
 class IntermineHandling(context: Context) {
@@ -18,11 +17,4 @@ class IntermineHandling(context: Context) {
   }
 
   lazy val connector = new IntermineConnector(instance, context.platformRegistry)
-
-  def importLists(user: String, pass: String): Iterable[GeneList] =
-    connector.importLists(user, pass).map(l => GeneList(l._2, l._1))
-
-  def exportLists(user: String, pass: String, lists: Iterable[GeneList], replace: Boolean): Unit =
-    connector.exportLists(user, pass, lists.map(l => (l.items, l.name)), replace)
-
 }

--- a/Toxygates/src/panomicon/IntermineHandling.scala
+++ b/Toxygates/src/panomicon/IntermineHandling.scala
@@ -1,0 +1,28 @@
+package panomicon
+
+import panomicon.json.GeneList
+import t.Context
+import t.server.viewer.intermine.IntermineConnector
+import t.shared.viewer.intermine.IntermineInstance
+
+class IntermineHandling(context: Context) {
+
+  lazy val instance = {
+    new IntermineInstance(
+      //Title displayed to the user
+      System.getenv("T_INTERMINE_NAME"),
+      //Internal ID string
+      System.getenv("T_INTERMINE_ID"),
+      //URL to application
+      System.getenv("T_INTERMINE_URL"))
+  }
+
+  lazy val connector = new IntermineConnector(instance, context.platformRegistry)
+
+  def importLists(user: String, pass: String): Iterable[GeneList] =
+    connector.importLists(user, pass).map(l => GeneList(l._2, l._1))
+
+  def exportLists(user: String, pass: String, lists: Iterable[GeneList], replace: Boolean): Unit =
+    connector.exportLists(user, pass, lists.map(l => (l.items, l.name)), replace)
+
+}

--- a/Toxygates/src/panomicon/ScalatraJSONServlet.scala
+++ b/Toxygates/src/panomicon/ScalatraJSONServlet.scala
@@ -684,12 +684,14 @@ class ScalatraJSONServlet(scontext: ServletContext) extends ScalatraServlet
   }
 
   /**
-   * Import gene lists from the configured intermine instance.
+   * Import gene lists from the configured intermine instance. A preferred platform for the import must be supplied.
    */
   get("/intermine/list") {
     val user = paramOrHalt("user")
     val pass = paramOrHalt("pass")
-    write(intermineHandling.connector.importLists(user, pass))
+    val platform = paramOrHalt("platform")
+    contentType = "text/json"
+    write(intermineHandling.connector.importLists(user, pass, Some(platform)))
   }
 
   /** Export gene lists to the configured intermine instance, optionally overwriting existing lists with the same name. */

--- a/Toxygates/src/panomicon/ScalatraJSONServlet.scala
+++ b/Toxygates/src/panomicon/ScalatraJSONServlet.scala
@@ -3,13 +3,13 @@ package panomicon
 import io.fusionauth.jwt.domain.JWT
 import org.scalatra._
 import org.scalatra.servlet.{FileUploadSupport, MultipartConfig}
-import panomicon.json.GeneList
 import t.db.Sample
 import t.model.sample.CoreParameter._
 import t.model.sample.Attribute
 import t.platform.{AffymetrixPlatform, BioPlatform, GeneralPlatform}
 import t.server.viewer.servlet.MinimalTServlet
 import t.server.viewer.Configuration
+import t.server.viewer.intermine.GeneList
 import t.shared.common.maintenance.BatchUploadException
 import t.shared.common.{AType, ValueType}
 import t.shared.viewer._
@@ -674,7 +674,7 @@ class ScalatraJSONServlet(scontext: ServletContext) extends ScalatraServlet
   get("/intermine/list") {
     val user = paramOrHalt("user")
     val pass = paramOrHalt("pass")
-    write(intermineHandling.importLists(user, pass))
+    write(intermineHandling.connector.importLists(user, pass))
   }
 
   /** Export gene lists to the configured intermine instance, optionally overwriting existing lists with the same name. */
@@ -683,6 +683,6 @@ class ScalatraJSONServlet(scontext: ServletContext) extends ScalatraServlet
     val pass = paramOrHalt("pass")
     val replace = (paramOrHalt("replace") == "true")
     val lists = read[Seq[GeneList]](request.body)
-    intermineHandling.exportLists(user, pass, lists, replace)
+    intermineHandling.connector.exportLists(user, pass, lists, replace)
   }
 }

--- a/Toxygates/src/panomicon/json/package.scala
+++ b/Toxygates/src/panomicon/json/package.scala
@@ -75,6 +75,9 @@ case class NetworkParams(groups1: Seq[Group], probes1: Seq[String] = Seq(),
   def matrix2: MatrixParams = MatrixParams(groups2)
 }
 
+object GeneList { implicit val rw: RW[GeneList] = macroRW }
+case class GeneList(name: String, items: Seq[String])
+
 object Encoders {
   // date should be added, either ISO 8601 or millis since 1970
   // https://stackoverflow.com/a/15952652/689356

--- a/Toxygates/src/panomicon/json/package.scala
+++ b/Toxygates/src/panomicon/json/package.scala
@@ -1,6 +1,7 @@
 package panomicon.json
 
 import t.db.BasicExprValue
+import t.server.viewer.intermine.GeneList
 import t.server.viewer.matrix.{ExpressionRow, ManagedMatrix}
 import t.shared.viewer.mirna.MirnaSource
 import t.shared.viewer.{ColumnFilter, FilterType}
@@ -75,9 +76,6 @@ case class NetworkParams(groups1: Seq[Group], probes1: Seq[String] = Seq(),
   def matrix2: MatrixParams = MatrixParams(groups2)
 }
 
-object GeneList { implicit val rw: RW[GeneList] = macroRW }
-case class GeneList(name: String, items: Seq[String])
-
 object Encoders {
   // date should be added, either ISO 8601 or millis since 1970
   // https://stackoverflow.com/a/15952652/689356
@@ -97,4 +95,5 @@ object Encoders {
   implicit val erRw: RW[ExpressionRow] = macroRW
   implicit val dsRW: RW[Dataset] = macroRW
   implicit val batRW: RW[Batch] = macroRW
+  implicit val glRW: RW[GeneList] = macroRW
 }

--- a/Toxygates/src/t/gwt/viewer/client/intermine/InterMineData.java
+++ b/Toxygates/src/t/gwt/viewer/client/intermine/InterMineData.java
@@ -62,7 +62,7 @@ public class InterMineData {
   /**
    * PreferredInstance must not be null
    */
-  public void importLists(final boolean asProbes) {
+  public void importLists() {
     final String slowImportMsg =
         "List import may take a long time if the data warehouse has many public lists.";
     InteractionDialog ui =
@@ -71,7 +71,7 @@ public class InterMineData {
           protected void userProceed(IntermineInstance instance, String user, String pass,
               boolean replace) {
             super.userProceed();
-            doImport(instance, user, pass, asProbes, replace);
+            doImport(instance, user, pass, replace);
           }
 
         };
@@ -79,8 +79,8 @@ public class InterMineData {
   }
 
   private void doImport(final IntermineInstance instance, final String user, final String pass,
-      final boolean asProbes, final boolean replace) {
-    tmService.importLists(instance, user, pass, asProbes, new PendingAsyncCallback<StringList[]>(
+      final boolean replace) {
+    tmService.importLists(instance, user, pass, new PendingAsyncCallback<StringList[]>(
         parent.manager(), "Unable to import lists from " + instance.title()) {
       @Override
       public void handleSuccess(StringList[] data) {

--- a/Toxygates/src/t/gwt/viewer/client/intermine/IntermineService.java
+++ b/Toxygates/src/t/gwt/viewer/client/intermine/IntermineService.java
@@ -32,12 +32,10 @@ public interface IntermineService extends RemoteService {
    * Import gene lists from an intermine user account.
    * 
    * @param user
-   * @param pass
-   * @param asProbes if true, the items will be imported as affymetrix probes. If false, as genes.
+   * @param pass*
    * @return
    */
-  StringList[] importLists(IntermineInstance instance,
-                           String user, String pass, boolean asProbes)
+  StringList[] importLists(IntermineInstance instance, String user, String pass)
       throws IntermineException;
 
   /**

--- a/Toxygates/src/t/gwt/viewer/client/intermine/IntermineServiceAsync.java
+++ b/Toxygates/src/t/gwt/viewer/client/intermine/IntermineServiceAsync.java
@@ -28,7 +28,7 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 public interface IntermineServiceAsync {
 
 	void importLists(IntermineInstance instance, String user,
-                     String pass, boolean asProbes, AsyncCallback<StringList[]> callback);
+                     String pass, AsyncCallback<StringList[]> callback);
 
 	void exportLists(IntermineInstance instance, String user,
                      String pass, StringList[] lists, boolean replace,

--- a/Toxygates/src/t/gwt/viewer/client/screen/ImportingScreen.java
+++ b/Toxygates/src/t/gwt/viewer/client/screen/ImportingScreen.java
@@ -63,7 +63,7 @@ public interface ImportingScreen extends Screen {
     MenuItem mi = new MenuItem(title + " data", mb);
 
     mb.addItem(new MenuItem("Import gene sets from " + title + "...", () -> {      
-      new InterMineData(this, inst).importLists(true);
+      new InterMineData(this, inst).importLists();
         Analytics.trackEvent(Analytics.CATEGORY_IMPORT_EXPORT, Analytics.ACTION_IMPORT_GENE_SETS,
             title);      
     }));

--- a/Toxygates/src/t/server/viewer/intermine/IntermineServiceImpl.scala
+++ b/Toxygates/src/t/server/viewer/intermine/IntermineServiceImpl.scala
@@ -50,7 +50,7 @@ class IntermineServiceImpl extends TServiceServlet with IntermineService {
   // Task: pass in a preferred species, get status info back
   def importLists(inst: IntermineInstance, user: String, pass: String): Array[StringList] = {
     val conn = mines.connector(inst, platforms)
-    conn.importLists(user, pass).map(l =>
+    conn.importLists(user, pass, None).map(l =>
       new StringList(StringList.PROBES_LIST_TYPE, l.name, l.items.toArray)
     ).toArray
   }

--- a/Toxygates/src/t/server/viewer/intermine/IntermineServiceImpl.scala
+++ b/Toxygates/src/t/server/viewer/intermine/IntermineServiceImpl.scala
@@ -51,7 +51,7 @@ class IntermineServiceImpl extends TServiceServlet with IntermineService {
   def importLists(inst: IntermineInstance, user: String, pass: String): Array[StringList] = {
     val conn = mines.connector(inst, platforms)
     conn.importLists(user, pass).map(l =>
-      new StringList(StringList.PROBES_LIST_TYPE, l._2, l._1)
+      new StringList(StringList.PROBES_LIST_TYPE, l.name, l.items.toArray)
     ).toArray
   }
 
@@ -59,7 +59,7 @@ class IntermineServiceImpl extends TServiceServlet with IntermineService {
       lists: Array[StringList], replace: Boolean): Unit = {
     val conn = mines.connector(inst, platforms)
     conn.exportLists(user, pass,
-      lists.map(l => (l.items().toSeq, l.name())), replace)
+      lists.map(l => GeneList(l.name(), l.items().toSeq)), replace)
   }
 
   // This is mainly to adjust the formatting of the p-value
@@ -82,7 +82,7 @@ class IntermineServiceImpl extends TServiceServlet with IntermineService {
     ls.setAuthentication(session)
     val tags = List()
 
-    val tempList = conn.addProbeList(ls, list.items(), "temp_enrichment", false, tags)
+    val tempList = conn.addProbeList(ls, GeneList("temp_enrichment", list.items()), false, tags)
 
     tempList match {
       case Some(tl) =>


### PR DESCRIPTION
This PR adds an API for exporting/importing named gene sets and the ability to configure an Intermine instance using environment variables. TargetMine connection details were added to .envrc.example.

To use these calls it is also necessary to supply username and password for the Intermine instance using the 'user' and 'pass' parameters. An account for TargetMine may be created on the TargetMine website https://targetmine.mizuguchilab.org.

Example data for import/export:

```json 
[
{
    "name": "glutathione",
    "items": [
      "1367834_at",
      "XM_003749458",      
      "XM_017591333",
      "1368354_at",
      "XM_008772860",
      "NM_053293", ...
  ] },
 {
    "name": "asdf2",
    "items": [
      "1433133_at",
      "1440162_x_at",
      "1433132_at",
      "1437800_at", ...
 ] }
]
```

Prior to export, gene lists are converted from probes (as in the example above) to entrez genes (they are stored in this format on the intermine instance), and when we import they are converted back into probes.
On my system this means that lists may grow considerably when imported back, as the entrez gene <-> probe mapping is many to many, and I have many different platforms  (any match in any platform would be included in the result). If this is becomes a problem, the effect might be avoided by supplying a desired platform or a representative sample group to the import call, to restrict the reverse conversion to relevant platforms only.

Example import request:
 GET http://localhost:4200/json/intermine/list?user=user@email.com&pass=xyz&platform=Rat230_2 - returns json data like the above (assuming Rat230_2 is a platform in the database)

Example export request:
POST http://localhost:4200/json/intermine/list?user=user@email.com&pass=xyz&replace=true with json data (example above) in the post body. All parameters are mandatory.

The following was tested:
* Importing gene lists (curl)
* Exporting gene lists (curl)
* Ensuring that exports with the replace=false flag does not overwrite existing lists with the same name
* Importing and exporting gene lists from the GWT application, ensuring that old functionality was not broken by these changes
* Importing with different target platforms, verifying that the results were correct

