### PR TITLE
For all user-facing requests, check roles and filter data or block the requests accordingly

### DIFF
--- a/OTGTool/src/main/scala/t/sparql/SampleStore.scala
+++ b/OTGTool/src/main/scala/t/sparql/SampleStore.scala
@@ -353,7 +353,7 @@ class SampleStore(bc: BaseConfig) extends ListManager(bc.triplestoreConfig)
    */
   def sampleAttributeValues(sampleIDs: Iterable[String], batches: Iterable[String],
                             queryAttribs: Iterable[Attribute] = Seq()): Seq[Sample] =
-    defaultAttributeQueries.sampleAttributeValues(sampleIDs, batches, queryAttribs)
+    defaultAttributeQueries.sampleAttributeValues(sampleIDs, batches, List(), queryAttribs)
 
 
   /**

--- a/Toxygates/src/panomicon/Authentication.scala
+++ b/Toxygates/src/panomicon/Authentication.scala
@@ -61,7 +61,9 @@ class Authentication {
 
   def getJwtToken(cookies: Array[Cookie]): Either[(JWT, String), String] = {
     try {
-      val tokenCookie = cookies.find(c => c.getName == "__Host-jwt").get
+      val tokenCookie = cookies.find(c => c.getName == "__Host-jwt").getOrElse(
+        return Right("JWT cookie __Host-jwt was not set")
+      )
 
       val jwt = new JWTDecoder().decode(tokenCookie.getValue,
         RSAVerifier.newVerifier(System.getenv("RSA_PUBLIC_KEY"))

--- a/Toxygates/src/panomicon/MatrixHandling.scala
+++ b/Toxygates/src/panomicon/MatrixHandling.scala
@@ -23,10 +23,13 @@ class MatrixHandling(context: Context, sampleFilter: SampleFilter) {
 
   def filledGroups(matParams: json.MatrixParams) = {
     val sampleIds = matParams.groups.flatMap(_.sampleIds)
+    //This will get all attributes and also filter samples that we do not have access to.
+    //Accordingly, not all requested sample IDs may be present in fullSamples.
+
     val fullSamples = Map.empty ++
       context.sampleStore.withRequiredAttributes(SampleClassFilter(), sampleFilter, sampleIds)().map(
         s => (s.sampleId -> s))
-    matParams.groups.map(g => fillGroup(g.name, g.sampleIds.map(s => fullSamples(s))))
+    matParams.groups.flatMap(g => checkAndFillGroup(g.name, g.sampleIds.flatMap(s => fullSamples.get(s))))
   }
 
   def loadMatrix(matParams: json.MatrixParams, valueType: ValueType): MatrixController = {
@@ -60,14 +63,12 @@ class MatrixHandling(context: Context, sampleFilter: SampleFilter) {
   }
 
   /**
-   * By using the sample treatment ID, ensure that the group contains
-   * all the available samples for a given treatment.
-   * This is the default behaviour for /matrix requests for now; in the future, we may want to
-   * make it optional, since the system in principle supports sub-treatment level sample groups.
+   * By using the sample treatment ID, ensure that the group contains all the available samples for a given treatment.
+   * @return A group with filled samples for the treatment if available, or None if the group could not be validated.
    */
-  def fillGroup(name: String, group: Seq[Sample]): t.shared.common.sample.Group = {
+  def checkAndFillGroup(name: String, group: Seq[Sample]): Option[t.shared.common.sample.Group] = {
     if (group.isEmpty) {
-      return new t.shared.common.sample.Group(name, Array[TUnit](), Array[TUnit]())
+      return None
     }
     val batchURI = group.head.apply(CoreParameter.Batch)
     val sf = sampleFilter.copy(batchURI = Some(batchURI))
@@ -80,7 +81,7 @@ class MatrixHandling(context: Context, sampleFilter: SampleFilter) {
     val treatedUnits = treatedTreatments.flatMap(t => unitForTreatment(sf, t))
     val controlUnits = controlTreatments.flatMap(t => unitForTreatment(sf, t))
 
-    new t.shared.common.sample.Group(name, treatedUnits.toArray, controlUnits.toArray)
+    Some(new t.shared.common.sample.Group(name, treatedUnits.toArray, controlUnits.toArray))
   }
 
   def rowsToJS(rows: Seq[ExpressionRow], matrixInfo: ManagedMatrixInfo): Seq[Map[String, Value]] = {

--- a/Toxygates/src/panomicon/MatrixHandling.scala
+++ b/Toxygates/src/panomicon/MatrixHandling.scala
@@ -15,10 +15,10 @@ import ujson.Value
 import upickle.default.writeJs
 
 /**
- * Routines that support matrix loading requests
+ * Routines that support matrix loading requests.
+ * @param sampleFilter allows filtering all data requests by batches, datasets, and/or instances.
  */
-class MatrixHandling(context: Context, sampleFilter: SampleFilter,
-                     tconfig: Configuration) {
+class MatrixHandling(context: Context, sampleFilter: SampleFilter) {
   lazy val associationLookup = new AssociationMasterLookup(context, sampleFilter)
 
   def filledGroups(matParams: json.MatrixParams) = {
@@ -70,7 +70,7 @@ class MatrixHandling(context: Context, sampleFilter: SampleFilter,
       return new t.shared.common.sample.Group(name, Array[TUnit](), Array[TUnit]())
     }
     val batchURI = group.head.apply(CoreParameter.Batch)
-    val sf = SampleFilter(tconfig.instanceURI, Some(batchURI))
+    val sf = sampleFilter.copy(batchURI = Some(batchURI))
 
     val treatedTreatments = group.map(s => s.sampleClass(Treatment)).distinct
     val controlTreatments = group.map(s => s.sampleClass(ControlTreatment)).distinct

--- a/Toxygates/src/panomicon/NetworkHandling.scala
+++ b/Toxygates/src/panomicon/NetworkHandling.scala
@@ -13,10 +13,10 @@ import scala.collection.JavaConverters._
 /**
  * Routines that support network loading requests
  */
-class NetworkHandling(context: Context, matrixHandling: MatrixHandling) {
+class NetworkHandling(context: Context) {
   lazy val netLoader = new NetworkLoader(context, context.config.data.mirnaDir)
 
-  def loadNetwork(valueType: ValueType, netParams: NetworkParams): Network = {
+  def loadNetwork(matrixHandling: MatrixHandling, valueType: ValueType, netParams: NetworkParams): Network = {
 
     val r = new TargetTableBuilder
     for (t <- netLoader.mirnaTargetTable(netParams.mirnaSource)) {

--- a/Toxygates/src/panomicon/NetworkHandling.scala
+++ b/Toxygates/src/panomicon/NetworkHandling.scala
@@ -9,6 +9,7 @@ import t.shared.viewer.network.{Interaction, Network, Node}
 import ujson.Value
 import upickle.default._
 import scala.collection.JavaConverters._
+import java.util.{ArrayList => JAList}
 
 /**
  * Routines that support network loading requests
@@ -32,6 +33,12 @@ class NetworkHandling(context: Context) {
     val mainGroups = matrixHandling.filledGroups(netParams.matrix1)
     val mainInitProbes = netParams.matrix1.probes
     val sideGroups = matrixHandling.filledGroups(netParams.matrix2)
+
+    //Groups may be empty due to sample filter
+    if (mainGroups.isEmpty || sideGroups.isEmpty) {
+      return new Network("empty", new JAList(), new JAList())
+    }
+
     val netController = netLoader.load(targetTable, mainGroups, mainInitProbes.toArray,
       sideGroups, valueType)
     netController.makeNetwork

--- a/Toxygates/src/panomicon/ScalatraJSONServlet.scala
+++ b/Toxygates/src/panomicon/ScalatraJSONServlet.scala
@@ -418,15 +418,17 @@ class ScalatraJSONServlet(scontext: ServletContext) extends ScalatraServlet
   def verifyDatasetAccess(datasetID: String): Unit = {
     val roles = getRoles(verifyJWT())
     if (!roles.contains(ADMIN_ROLE) && !roles.contains(datasetID)) {
-      halt(401, s"You do not have access to this dataset")
+      halt(401, s"You do not have access to dataset $datasetID. Your roles are: ${roles.mkString(", ")}")
     }
   }
 
   def verifyBatchAccess(batchID: String): Unit = {
     val roles = getRoles(verifyJWT())
     val batchToDataset = batchStore.getDatasets()
-    if (!roles.contains(ADMIN_ROLE) && !roles.contains(batchToDataset(batchID))) {
-      halt(401, s"You do not have access to this batch")
+    val neededRole = batchToDataset(batchID)
+    if (!roles.contains(ADMIN_ROLE) && !roles.contains(neededRole)) {
+      halt(401, s"You do not have access to batch $batchID. Your roles are: ${roles.mkString(", ")}." +
+        s" You would need the role: $neededRole")
     }
   }
 

--- a/Toxygates/src/panomicon/ScalatraJSONServlet.scala
+++ b/Toxygates/src/panomicon/ScalatraJSONServlet.scala
@@ -328,7 +328,15 @@ class ScalatraJSONServlet(scontext: ServletContext) extends ScalatraServlet
       sampleStore.defaultAttributeQueries
     }
 
-    val attributes: Seq[Attribute] = params("attributes").arr.map(v => queries.attributeSet.byId(v.str))
+    val attributes: Seq[Attribute] = params("attributes").arr.flatMap(v => {
+      Option(queries.attributeSet.byId(v.str)) match {
+        case Some(a) =>
+          Some(a)
+        case None =>
+          println(s"Unknown attribute requested: ${v.str}")
+          None
+      }
+    })
     val samplesWithValues = queries.sampleAttributeValues(sampleIds, batches, datasets, attributes)
     write(samplesWithValues.map(sampleToMap))
   }

--- a/Toxygates/src/panomicon/ScalatraJSONServlet.scala
+++ b/Toxygates/src/panomicon/ScalatraJSONServlet.scala
@@ -375,6 +375,10 @@ class ScalatraJSONServlet(scontext: ServletContext) extends ScalatraServlet
   }
 
   def verifyJWT(): JWT = {
+    if (request.getCookies == null) {
+      println("Request has no cookies, unable to verify JWT")
+      halt(401)
+    }
     authentication.getJwtToken(request.getCookies) match {
       case Left((token, tokenString)) => {
         response.addHeader("Set-Cookie", authentication.cookieHeader(tokenString))
@@ -389,7 +393,10 @@ class ScalatraJSONServlet(scontext: ServletContext) extends ScalatraServlet
 
   /* Role IDs also correspond to the set of datasets a user can access. */
   def getRoles(jwt: JWT): Set[String] = {
-    jwt.getList("roles").asInstanceOf[util.List[String]].asScala.toSet
+    Option(jwt.getList("roles")) match {
+      case Some(l) => l.asInstanceOf[util.List[String]].asScala.toSet
+      case None => Set.empty
+    }
   }
 
   def verifyRole(role: String): JWT = {

--- a/Toxygates/src/panomicon/ScalatraJSONServlet.scala
+++ b/Toxygates/src/panomicon/ScalatraJSONServlet.scala
@@ -427,8 +427,8 @@ class ScalatraJSONServlet(scontext: ServletContext) extends ScalatraServlet
     val batchToDataset = batchStore.getDatasets()
     val neededRole = batchToDataset(batchID)
     if (!roles.contains(ADMIN_ROLE) && !roles.contains(neededRole)) {
-      halt(401, s"You do not have access to batch $batchID. Your roles are: ${roles.mkString(", ")}." +
-        s" You would need the role: $neededRole")
+      Console.err.println(s"The user requested access to batch $batchID, but they do not have the role $neededRole")
+      halt(401, s"You do not have access to batch $batchID. Your roles are: ${roles.mkString(", ")}.")
     }
   }
 

--- a/Toxygates/src/t/server/viewer/rpc/SampleServiceImpl.scala
+++ b/Toxygates/src/t/server/viewer/rpc/SampleServiceImpl.scala
@@ -90,10 +90,9 @@ class SampleServiceImpl extends StatefulServlet[SampleState] with SampleService 
 
   private def sampleFilterFor(datasets: Iterable[Dataset], base: Option[SampleFilter]) = {
      val ids = datasets.toList.map(_.getId)
-     val URIs = ids.map(DatasetStore.packURI(_))
      base match {
-       case Some(b) => b.copy(datasetURIs = URIs)
-       case None => SampleFilter(datasetURIs = URIs)
+       case Some(b) => b.copy(datasetIDs = ids)
+       case None => SampleFilter(datasetIDs = ids)
      }
   }
 

--- a/Toxygates/src/t/server/viewer/rpc/SeriesServiceImpl.scala
+++ b/Toxygates/src/t/server/viewer/rpc/SeriesServiceImpl.scala
@@ -73,8 +73,7 @@ class SeriesServiceImpl extends TServiceServlet with SeriesService {
 
   private def allowedMajors(ds: Array[Dataset], sc: SampleClass): Set[String] = {
     val ids = ds.map(_.getId).distinct.toList
-    val sf = SampleFilter(instanceURI = config.instanceURI,
-        datasetURIs = ids.map(DatasetStore.packURI(_)))
+    val sf = SampleFilter(instanceURI = config.instanceURI, datasetIDs = ids)
 
     val majAttr = schema.majorParameter()
 


### PR DESCRIPTION
This adds role checking to the following requests:
/dataset, /batch/dataset,  /sample/batch,  /sample/treatment,  /sample,  /parameterValues, /matrix, /network,  /association, /attribute/batch, /attributeValues.

There's no checking for /platform/user as platform data is deemed to be not sensitive, neither for intermine export/import as those requests do not give access to any data in our system, other than platform data.

In general, this verifies that the user either has access to the requested dataset/datasets (directly or indirectly when a sample or batch is requested), or that the user has admin access, in which case everything can be accessed. If the required role is not present, and the user is not admin, the request is blocked. 
However, for some requests, like /matrix and /network, if the user requests blocked samples, the blocked samples will quietly be filtered out and a filtered (or empty) result will be returned. This was easiest to implement (and in any case should not occur during normal usage, since there should be no way to discover those sample IDs in the first place).

From curl, I tested a variety of requests from both an admin role and from a role with access to only one dataset and verified that the result changed, or that the request failed, accordingly. I also tested various functions in the web application and verified that it behaved correctly.


